### PR TITLE
fix: 게하 등록 주소 변환과 상세 탭 스크롤 개선

### DIFF
--- a/app/guestHouse/enroll/step5.tsx
+++ b/app/guestHouse/enroll/step5.tsx
@@ -1,5 +1,4 @@
 import { Href, router, useFocusEffect } from "expo-router";
-import axios from "axios";
 import { useCallback, useRef } from "react";
 import { KeyboardAvoidingView, Platform, ScrollView, View } from "react-native";
 
@@ -8,7 +7,6 @@ import Button from "@/src/components/ui/Button/Button";
 import FormField from "@/src/components/ui/Form/FormField";
 import FormSection from "@/src/components/ui/Form/FormSection";
 import TextInput from "@/src/components/ui/TextInput";
-import { useRequireLogin } from "@/src/hooks/common/useRequireLogin";
 import { useGuestHouseEnrollment } from "@/src/hooks/guestHouse/useGuestHouseEnrollment";
 import { useGuestHouseStep1Validation } from "@/src/hooks/guestHouse/useGuestHouseStep1Validation";
 import { useGuestHouseStep2Validation } from "@/src/hooks/guestHouse/useGuestHouseStep2Validation";
@@ -38,7 +36,6 @@ export default function GuestHouseEnrollStep5() {
     editingId,
   } = useGuestHouseStore();
   const { instagram, phone, website, ownerMessage } = step5Data;
-  const { requireLogin } = useRequireLogin();
 
   const { validateForm: validateStep1 } =
     useGuestHouseStep1Validation(step1Data);
@@ -128,12 +125,6 @@ export default function GuestHouseEnrollStep5() {
   };
 
   const handleSubmit = async () => {
-    let canSubmit = false;
-    requireLogin(() => {
-      canSubmit = true;
-    });
-    if (!canSubmit) return;
-
     if (!validateStepAndNavigate(validateStep1, "/guestHouse/enroll/step1"))
       return;
     if (!validateStepAndNavigate(validateStep2, "/guestHouse/enroll/step2"))
@@ -180,12 +171,7 @@ export default function GuestHouseEnrollStep5() {
 
       let userFriendlyMessage = "등록 중 오류가 발생했습니다.";
 
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        userFriendlyMessage = "로그인 후 다시 등록해주세요.";
-      } else if (axios.isAxiosError(error) && error.response?.status === 403) {
-        userFriendlyMessage =
-          "게스트하우스 등록은 인증서 심사가 완료된 사장님만 가능합니다.";
-      } else if (error instanceof Error) {
+      if (error instanceof Error) {
         if (error.message.includes("이미지")) {
           userFriendlyMessage = error.message;
         } else if (error.message.includes("네트워크")) {

--- a/app/guestHouse/guestHouseDetail/[id]/index.tsx
+++ b/app/guestHouse/guestHouseDetail/[id]/index.tsx
@@ -109,7 +109,7 @@ export default function GuestHouseDetail() {
           <ScrollView
             ref={scrollViewRef}
             stickyHeaderIndices={[2]}
-            contentContainerStyle={{ paddingBottom: 24 }}
+            contentContainerStyle={{ paddingBottom: 240 }}
           >
             <GehaImage images={data?.imageUrls} height={280} page={true} />
 

--- a/app/guestHouse/guestHouseDetail/[id]/index.tsx
+++ b/app/guestHouse/guestHouseDetail/[id]/index.tsx
@@ -33,10 +33,13 @@ export default function GuestHouseDetail() {
     sectionToScroll,
     setContainerOffset,
     setStickyHeaderHeight,
+    createSectionScrollHandler,
   } = useSectionToScroll();
-  const { selectedSection, handleSectionToScroll } = useHandleSection({
-    sectionToScroll,
-  });
+  const { selectedSection, setSelectedSection, handleSectionToScroll } =
+    useHandleSection({
+      sectionToScroll,
+    });
+  const guestHouseSectionOrder = GUESTHOUSE.map(({ section }) => section);
 
   const { data, isPending, isError, refetch } = useGuestHouseDetail();
   const { requireLogin } = useRequireLogin();
@@ -110,6 +113,11 @@ export default function GuestHouseDetail() {
             ref={scrollViewRef}
             stickyHeaderIndices={[2]}
             contentContainerStyle={{ paddingBottom: 240 }}
+            onScroll={createSectionScrollHandler(
+              guestHouseSectionOrder,
+              setSelectedSection,
+            )}
+            scrollEventThrottle={16}
           >
             <GehaImage images={data?.imageUrls} height={280} page={true} />
 

--- a/app/guestHouse/guestHouseDetail/[id]/index.tsx
+++ b/app/guestHouse/guestHouseDetail/[id]/index.tsx
@@ -24,6 +24,8 @@ import GuestHouseIntro from "../_components/GuestHouseIntro";
 import GuestHouseParty from "../_components/GuestHouseParty";
 import ParlorType from "../_components/ParlorType";
 
+const guestHouseSectionOrder = GUESTHOUSE.map(({ section }) => section);
+
 export default function GuestHouseDetail() {
   const { id, fromRegistration } = useLocalSearchParams<{ id: string; fromRegistration?: string }>();
 
@@ -39,7 +41,6 @@ export default function GuestHouseDetail() {
     useHandleSection({
       sectionToScroll,
     });
-  const guestHouseSectionOrder = GUESTHOUSE.map(({ section }) => section);
 
   const { data, isPending, isError, refetch } = useGuestHouseDetail();
   const { requireLogin } = useRequireLogin();

--- a/app/step/stepDetail/[id]/index.tsx
+++ b/app/step/stepDetail/[id]/index.tsx
@@ -128,7 +128,7 @@ export default function StepDetail() {
           <ScrollView
             ref={scrollViewRef}
             stickyHeaderIndices={[2]}
-            contentContainerStyle={{ paddingBottom: 24 }}
+            contentContainerStyle={{ paddingBottom: 240 }}
           >
             <GehaImage
               images={data?.representativeImages}

--- a/app/step/stepDetail/[id]/index.tsx
+++ b/app/step/stepDetail/[id]/index.tsx
@@ -38,10 +38,13 @@ export default function StepDetail() {
     sectionToScroll,
     setContainerOffset,
     setStickyHeaderHeight,
+    createSectionScrollHandler,
   } = useSectionToScroll();
-  const { selectedSection, handleSectionToScroll } = useHandleSection({
-    sectionToScroll,
-  });
+  const { selectedSection, setSelectedSection, handleSectionToScroll } =
+    useHandleSection({
+      sectionToScroll,
+    });
+  const stepDetailSectionOrder = STEP_DETAIL.map(({ section }) => section);
 
   const handleApply = () => {
     setIsVisible(false);
@@ -129,6 +132,11 @@ export default function StepDetail() {
             ref={scrollViewRef}
             stickyHeaderIndices={[2]}
             contentContainerStyle={{ paddingBottom: 240 }}
+            onScroll={createSectionScrollHandler(
+              stepDetailSectionOrder,
+              setSelectedSection,
+            )}
+            scrollEventThrottle={16}
           >
             <GehaImage
               images={data?.representativeImages}

--- a/app/step/stepDetail/[id]/index.tsx
+++ b/app/step/stepDetail/[id]/index.tsx
@@ -29,6 +29,8 @@ import StepDetailModal from "../_components/Modal/StepDetailModal";
 import PressSection from "../_components/PressSection/PressSection";
 import WorkInfo from "../_components/WorkInfo/WorkInfo";
 
+const stepDetailSectionOrder = STEP_DETAIL.map(({ section }) => section);
+
 export default function StepDetail() {
   const { id, fromRegistration } = useLocalSearchParams<{ id: string; fromRegistration?: string }>();
 
@@ -44,7 +46,6 @@ export default function StepDetail() {
     useHandleSection({
       sectionToScroll,
     });
-  const stepDetailSectionOrder = STEP_DETAIL.map(({ section }) => section);
 
   const handleApply = () => {
     setIsVisible(false);

--- a/app/step/stepDetail/_components/PressSection/PressSection.tsx
+++ b/app/step/stepDetail/_components/PressSection/PressSection.tsx
@@ -1,4 +1,5 @@
-import Flex from "@/src/components/layout/Flex/Flex";
+import { ScrollView } from "react-native";
+
 import { PressSectionItems } from "@/src/utils/constants/pressSection";
 import PressSectionToScroll from "./PressSectionToScroll";
 
@@ -14,7 +15,14 @@ export default function PressSection({
   selectedSection,
 }: PressSectionProps) {
   return (
-    <Flex items='center' justify='between' dir='row' wrap='wrap' className='px-5'>
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{
+        paddingHorizontal: 16,
+        gap: 8,
+      }}
+    >
       {items.map(({ section, content }) => (
         <PressSectionToScroll
           key={section}
@@ -24,6 +32,6 @@ export default function PressSection({
           isActive={selectedSection === section}
         />
       ))}
-    </Flex>
+    </ScrollView>
   );
 }

--- a/app/step/stepDetail/_components/PressSection/PressSectionToScroll.tsx
+++ b/app/step/stepDetail/_components/PressSection/PressSectionToScroll.tsx
@@ -19,7 +19,7 @@ export default function PressSectionToScroll({
     <Pressable
       hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
       className='min-w-[58px] h-10 px-2 items-center justify-center'
-      onPressIn={() => handleSectionToScroll(section)}
+      onPress={() => handleSectionToScroll(section)}
     >
       <TextSize
         content={content}

--- a/app/step/stepDetail/_components/PressSection/PressSectionToScroll.tsx
+++ b/app/step/stepDetail/_components/PressSection/PressSectionToScroll.tsx
@@ -16,14 +16,20 @@ export default function PressSectionToScroll({
   isActive,
 }: PressSectionToScrollProps) {
   return (
-    <Pressable onPress={() => handleSectionToScroll(section)}>
+    <Pressable
+      hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+      className='min-w-[58px] h-10 px-2 items-center justify-center'
+      onPressIn={() => handleSectionToScroll(section)}
+    >
       <TextSize
         content={content}
         size={14}
         color={isActive ? "#0084D1" : "#6A7282"}
       />
-      <View className='pt-3' />
-      {isActive && <View className='border border-b border-[#0084D1]' />}
+      <View
+        className='absolute bottom-0 left-2 right-2 border-b-2'
+        style={{ borderColor: isActive ? "#0084D1" : "transparent" }}
+      />
     </Pressable>
   );
 }

--- a/src/hooks/common/useHandleSection.ts
+++ b/src/hooks/common/useHandleSection.ts
@@ -16,6 +16,7 @@ export const useHandleSection = ({
 
   return {
     selectedSection,
+    setSelectedSection,
     handleSectionToScroll,
   };
 };

--- a/src/hooks/common/useSectionToScroll.ts
+++ b/src/hooks/common/useSectionToScroll.ts
@@ -1,14 +1,31 @@
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ScrollView } from "react-native";
 
 export const useSectionToScroll = () => {
   const scrollViewRef = useRef<ScrollView>(null);
   const containerOffsetRef = useRef<number>(0);
   const stickyHeaderHeightRef = useRef<number>(0);
+  const sectionYPositionsRef = useRef<{ [key: string]: number }>({});
 
   const [sectionYPositions, setSectionYPositions] = useState<{
     [key: string]: number;
   }>({});
+
+  const updateSectionYPositions = useCallback(
+    (
+      updater:
+        | { [key: string]: number }
+        | ((prev: { [key: string]: number }) => { [key: string]: number }),
+    ) => {
+      setSectionYPositions((prev) => {
+        const next =
+          typeof updater === "function" ? updater(sectionYPositionsRef.current) : updater;
+        sectionYPositionsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
 
   const setContainerOffset = (y: number) => {
     containerOffsetRef.current = y;
@@ -18,19 +35,24 @@ export const useSectionToScroll = () => {
     stickyHeaderHeightRef.current = h;
   };
 
-  const sectionToScroll = (key: string) => {
-    const localY = sectionYPositions[key];
-    if (localY !== undefined) {
+  const sectionToScroll = (key: string, retryCount = 0) => {
+    const localY = sectionYPositionsRef.current[key] ?? sectionYPositions[key];
+    if (localY === undefined) {
+      if (retryCount < 3) {
+        setTimeout(() => sectionToScroll(key, retryCount + 1), 100);
+      }
+      return;
+    }
+
       const absoluteY =
         containerOffsetRef.current + localY - stickyHeaderHeightRef.current - 16;
       scrollViewRef.current?.scrollTo({ y: absoluteY, animated: true });
-    }
   };
 
   return {
     scrollViewRef,
     sectionToScroll,
-    setSectionYPositions,
+    setSectionYPositions: updateSectionYPositions,
     setContainerOffset,
     setStickyHeaderHeight,
   };

--- a/src/hooks/common/useSectionToScroll.ts
+++ b/src/hooks/common/useSectionToScroll.ts
@@ -1,11 +1,19 @@
 import { useCallback, useRef, useState } from "react";
-import { ScrollView } from "react-native";
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+} from "react-native";
 
 export const useSectionToScroll = () => {
   const scrollViewRef = useRef<ScrollView>(null);
   const containerOffsetRef = useRef<number>(0);
   const stickyHeaderHeightRef = useRef<number>(0);
   const sectionYPositionsRef = useRef<{ [key: string]: number }>({});
+  const isProgrammaticScrollRef = useRef(false);
+  const programmaticScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const [sectionYPositions, setSectionYPositions] = useState<{
     [key: string]: number;
@@ -35,6 +43,35 @@ export const useSectionToScroll = () => {
     stickyHeaderHeightRef.current = h;
   };
 
+  const getActiveSection = (scrollY: number, sectionOrder: string[]) => {
+    const sectionYPositions = sectionYPositionsRef.current;
+    const currentY =
+      scrollY - containerOffsetRef.current + stickyHeaderHeightRef.current + 32;
+
+    return sectionOrder.reduce((activeSection, section) => {
+      const sectionY = sectionYPositions[section];
+
+      if (sectionY !== undefined && sectionY <= currentY) {
+        return section;
+      }
+
+      return activeSection;
+    }, sectionOrder[0]);
+  };
+
+  const createSectionScrollHandler =
+    (sectionOrder: string[], onSectionChange: (section: string) => void) =>
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (isProgrammaticScrollRef.current) return;
+
+      const activeSection = getActiveSection(
+        event.nativeEvent.contentOffset.y,
+        sectionOrder,
+      );
+
+      onSectionChange(activeSection);
+    };
+
   const sectionToScroll = (key: string, retryCount = 0) => {
     const localY = sectionYPositionsRef.current[key] ?? sectionYPositions[key];
     if (localY === undefined) {
@@ -46,6 +83,13 @@ export const useSectionToScroll = () => {
 
       const absoluteY =
         containerOffsetRef.current + localY - stickyHeaderHeightRef.current - 16;
+      isProgrammaticScrollRef.current = true;
+      if (programmaticScrollTimerRef.current) {
+        clearTimeout(programmaticScrollTimerRef.current);
+      }
+      programmaticScrollTimerRef.current = setTimeout(() => {
+        isProgrammaticScrollRef.current = false;
+      }, 450);
       scrollViewRef.current?.scrollTo({ y: absoluteY, animated: true });
   };
 
@@ -55,5 +99,6 @@ export const useSectionToScroll = () => {
     setSectionYPositions: updateSectionYPositions,
     setContainerOffset,
     setStickyHeaderHeight,
+    createSectionScrollHandler,
   };
 };

--- a/src/hooks/common/useSectionToScroll.ts
+++ b/src/hooks/common/useSectionToScroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -34,6 +34,14 @@ export const useSectionToScroll = () => {
     },
     [],
   );
+
+  useEffect(() => {
+    return () => {
+      if (programmaticScrollTimerRef.current) {
+        clearTimeout(programmaticScrollTimerRef.current);
+      }
+    };
+  }, []);
 
   const setContainerOffset = (y: number) => {
     containerOffsetRef.current = y;
@@ -72,8 +80,8 @@ export const useSectionToScroll = () => {
       onSectionChange(activeSection);
     };
 
-  const sectionToScroll = (key: string, retryCount = 0) => {
-    const localY = sectionYPositionsRef.current[key] ?? sectionYPositions[key];
+  const sectionToScroll = useCallback((key: string, retryCount = 0) => {
+    const localY = sectionYPositionsRef.current[key];
     if (localY === undefined) {
       if (retryCount < 3) {
         setTimeout(() => sectionToScroll(key, retryCount + 1), 100);
@@ -81,17 +89,17 @@ export const useSectionToScroll = () => {
       return;
     }
 
-      const absoluteY =
-        containerOffsetRef.current + localY - stickyHeaderHeightRef.current - 16;
-      isProgrammaticScrollRef.current = true;
-      if (programmaticScrollTimerRef.current) {
-        clearTimeout(programmaticScrollTimerRef.current);
-      }
-      programmaticScrollTimerRef.current = setTimeout(() => {
-        isProgrammaticScrollRef.current = false;
-      }, 450);
-      scrollViewRef.current?.scrollTo({ y: absoluteY, animated: true });
-  };
+    const absoluteY =
+      containerOffsetRef.current + localY - stickyHeaderHeightRef.current - 16;
+    isProgrammaticScrollRef.current = true;
+    if (programmaticScrollTimerRef.current) {
+      clearTimeout(programmaticScrollTimerRef.current);
+    }
+    programmaticScrollTimerRef.current = setTimeout(() => {
+      isProgrammaticScrollRef.current = false;
+    }, 450);
+    scrollViewRef.current?.scrollTo({ y: absoluteY, animated: true });
+  }, []);
 
   return {
     scrollViewRef,

--- a/src/utils/guestHouse/enrollDataTransformer.ts
+++ b/src/utils/guestHouse/enrollDataTransformer.ts
@@ -100,8 +100,8 @@ const transformLocation = (
   }
 
   return {
-    lotNumberAddress: location.jibunAddress || '',
-    roadNameAddress: location.roadAddress || '',
+    lotNumberAddress: location.jibunAddress || location.roadAddress || '',
+    roadNameAddress: location.roadAddress || location.jibunAddress || '',
     coordinates: [location.longitude ?? 0, location.latitude ?? 0],
   };
 };

--- a/src/utils/stepRecruitment/transformStoreToApi.ts
+++ b/src/utils/stepRecruitment/transformStoreToApi.ts
@@ -34,8 +34,10 @@ export const transformStoreToApi = (
   const { step1Data, step2Data, step3Data, step4Data, step5Data } = store;
 
   const location: LocationRequest = {
-    lotNumberAddress: step1Data.location?.jibunAddress || '',
-    roadNameAddress: step1Data.location?.roadAddress || '',
+    lotNumberAddress:
+      step1Data.location?.jibunAddress || step1Data.location?.roadAddress || '',
+    roadNameAddress:
+      step1Data.location?.roadAddress || step1Data.location?.jibunAddress || '',
     coordinates: [
       step1Data.location?.longitude || 0,
       step1Data.location?.latitude || 0,


### PR DESCRIPTION

## 작업 내용

- 게하 등록 제출 전 추가했던 프론트 로그인 사전 체크를 제거
- 게스트하우스 상세/스텝 상세 페이지의 탭 스크롤 동작을 안정화
- 게하 등록/스텝 공고 등록 주소 변환 시 fallback을 추가
- 상세 탭의 활성 상태 갱신을 보완


## 리뷰어가 중점적으로 봐야할 부분은 무엇인가요?

---

