### PR TITLE
feat: 지역·분위기·객실 정보 개편 반영

### DIFF
--- a/app/guestHouse/_components/RegionFilter.tsx
+++ b/app/guestHouse/_components/RegionFilter.tsx
@@ -16,11 +16,11 @@ export default function RegionFilter({
   return (
     <View className='flex-row flex-wrap gap-2'>
       {REGION_OPTIONS.map((region) => {
-        const isSelected = selectedRegions.includes(region);
+        const isSelected = selectedRegions.includes(region.value);
         return (
           <Pressable
-            key={region}
-            onPress={() => onToggle("region", region)}
+            key={region.value}
+            onPress={() => onToggle("region", region.value)}
             className={`flex-row items-center gap-2 p-3 rounded-lg border ${
               isSelected
                 ? "border-primary-blue bg-blue-50"
@@ -29,7 +29,7 @@ export default function RegionFilter({
             style={{ width: "48%" }}
           >
             <Checkbox checked={isSelected} size='md' />
-            <TextSize size={14} content={region} />
+            <TextSize size={14} content={region.label} />
           </Pressable>
         );
       })}

--- a/app/guestHouse/enroll/_components/step2/AtmosphereSelector.tsx
+++ b/app/guestHouse/enroll/_components/step2/AtmosphereSelector.tsx
@@ -47,13 +47,13 @@ const AtmosphereSelector = ({
       <View className="bg-white rounded-xl border border-gray-200 p-4">
         <View className="flex-row flex-wrap">
           {ATMOSPHERE_OPTIONS.map((atmosphereOption) => {
-            const isSelected = step2Data.atmosphere.includes(atmosphereOption);
+            const isSelected = step2Data.atmosphere.includes(atmosphereOption.value);
             return (
               <SelectableTag
-                key={atmosphereOption}
-                label={`#${atmosphereOption}`}
+                key={atmosphereOption.value}
+                label={atmosphereOption.label}
                 selected={isSelected}
-                onPress={() => toggleAtmosphere(atmosphereOption)}
+                onPress={() => toggleAtmosphere(atmosphereOption.value)}
               />
             );
           })}

--- a/app/guestHouse/enroll/_components/step3/RoomCard.tsx
+++ b/app/guestHouse/enroll/_components/step3/RoomCard.tsx
@@ -4,12 +4,29 @@ import { Image, Text, TouchableOpacity, View } from 'react-native';
 
 import { formatTime } from '@/src/utils/common/dateFormatter';
 
+const getRoomTypeColor = (type: string) => {
+  if (type === '여성 전용 도미토리') {
+    return '#fa2b36';
+  }
+
+  if (type === '남성 전용 도미토리') {
+    return '#3b82f6';
+  }
+
+  return '#99a1af';
+};
+
+const formatOccupancyLabel = (occupancy: string) => {
+  const count = occupancy.replace(/[^0-9]/g, '');
+  return count ? `${count}인` : occupancy;
+};
+
 interface RoomCardProps {
   room: {
     id: string;
     name: string;
-    type: '여성 전용 도미토리' | '남성 전용 도미토리';
-    occupancy: '1인실' | '2인실' | '3인이상';
+    type: '여성 전용 도미토리' | '남성 전용 도미토리' | '기타';
+    occupancy: string;
     checkInTime: Date;
     checkOutTime: Date;
     price: string;
@@ -75,12 +92,11 @@ const RoomCard = ({
             <View
               className="w-2 h-2 rounded-full"
               style={{
-                backgroundColor:
-                  room.type === '여성 전용 도미토리' ? '#fa2b36' : '#3b82f6',
+                backgroundColor: getRoomTypeColor(room.type),
               }}
             />
             <Text className="text-[#6a7282] text-xs">
-              {room.type} · {room.occupancy}
+              {room.type} · {formatOccupancyLabel(room.occupancy)}
             </Text>
           </View>
         </View>

--- a/app/guestHouse/enroll/addRoomForm.tsx
+++ b/app/guestHouse/enroll/addRoomForm.tsx
@@ -8,7 +8,6 @@ import { File } from "@/src/types/File";
 import {
   BUTTON_LABELS,
   FORM_DESCRIPTIONS,
-  OCCUPANCY_OPTIONS,
   PLACEHOLDERS,
   ROOM_TYPE_COLORS,
   ROOM_TYPES,
@@ -41,8 +40,10 @@ const FormLabel = ({
   </View>
 );
 
-type RoomType = "여성 전용 도미토리" | "남성 전용 도미토리";
-type Occupancy = "1인실" | "2인실" | "3인이상";
+type RoomType = "여성 전용 도미토리" | "남성 전용 도미토리" | "기타";
+
+const normalizeOccupancyInput = (value: string) =>
+  value.replace(/[^0-9]/g, "");
 
 const SelectButton = ({
   label,
@@ -111,7 +112,7 @@ export default function AddRoomForm() {
 
   const [roomName, setRoomName] = useState("");
   const [roomType, setRoomType] = useState<RoomType | null>(null);
-  const [occupancy, setOccupancy] = useState<Occupancy | null>(null);
+  const [occupancy, setOccupancy] = useState("");
   const [checkInTime, setCheckInTime] = useState(getDefaultCheckInTime());
   const [checkOutTime, setCheckOutTime] = useState(getDefaultCheckOutTime());
   const [price, setPrice] = useState("");
@@ -123,7 +124,7 @@ export default function AddRoomForm() {
       if (existingRoom) {
         setRoomName(existingRoom.name);
         setRoomType(existingRoom.type);
-        setOccupancy(existingRoom.occupancy);
+        setOccupancy(normalizeOccupancyInput(existingRoom.occupancy));
         setCheckInTime(existingRoom.checkInTime);
         setCheckOutTime(existingRoom.checkOutTime);
         setPrice(existingRoom.price);
@@ -136,7 +137,7 @@ export default function AddRoomForm() {
     id: "",
     name: roomName,
     type: roomType || ("여성 전용 도미토리" as RoomType),
-    occupancy: occupancy || ("1인실" as Occupancy),
+    occupancy: occupancy || "1",
     checkInTime,
     checkOutTime,
     price,
@@ -180,7 +181,7 @@ export default function AddRoomForm() {
     const validationData = {
       ...roomData,
       type: roomType,
-      occupancy: occupancy,
+      occupancy,
     };
 
     const isValid = validateRoomForm(validationData as any);
@@ -206,7 +207,7 @@ export default function AddRoomForm() {
   const resetForm = () => {
     setRoomName("");
     setRoomType(null);
-    setOccupancy(null);
+    setOccupancy("");
     setCheckInTime(getDefaultCheckInTime());
     setCheckOutTime(getDefaultCheckOutTime());
     setPrice("");
@@ -296,32 +297,20 @@ export default function AddRoomForm() {
             {/* 객실 인원 */}
             <View ref={fieldRefs.occupancy}>
               <FormLabel text='객실 인원' required />
-              <View className='flex-row gap-2 mt-2'>
-                {OCCUPANCY_OPTIONS.map((label) => (
-                  <TouchableOpacity
-                    key={label}
-                    onPress={() => {
-                      setOccupancy(label);
-                      clearRoomError("occupancy");
-                    }}
-                    className={`flex-1 h-11 rounded-lg border justify-center items-center ${
-                      occupancy === label
-                        ? "bg-sky-50 border-sky-500"
-                        : "bg-white border-gray-200"
-                    }`}
-                  >
-                    <Text
-                      className={`text-sm ${
-                        occupancy === label
-                          ? "text-sky-500 font-medium"
-                          : "text-[#364153]"
-                      }`}
-                    >
-                      {label}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
+              <TextInput
+                className={`w-full h-12 px-4 rounded-lg border text-sm mt-2 ${
+                  roomErrors.occupancy ? "border-red-500" : "border-gray-200"
+                }`}
+                placeholder='예: 4'
+                placeholderTextColor={ROOM_TYPE_COLORS.PLACEHOLDER}
+                value={occupancy}
+                keyboardType='number-pad'
+                onChangeText={(text) => {
+                  setOccupancy(normalizeOccupancyInput(text));
+                  clearRoomError("occupancy");
+                }}
+                onFocus={() => clearRoomError("occupancy")}
+              />
               {roomErrors.occupancy && (
                 <Text className='text-red-500 text-xs mt-1'>
                   {roomErrors.occupancy}

--- a/app/guestHouse/enroll/addRoomForm.tsx
+++ b/app/guestHouse/enroll/addRoomForm.tsx
@@ -136,8 +136,8 @@ export default function AddRoomForm() {
   const roomData = {
     id: "",
     name: roomName,
-    type: roomType || ("여성 전용 도미토리" as RoomType),
-    occupancy: occupancy || "1",
+    type: roomType,
+    occupancy,
     checkInTime,
     checkOutTime,
     price,
@@ -178,13 +178,7 @@ export default function AddRoomForm() {
   };
 
   const handleAddRoom = () => {
-    const validationData = {
-      ...roomData,
-      type: roomType,
-      occupancy,
-    };
-
-    const isValid = validateRoomForm(validationData as any);
+    const isValid = validateRoomForm(roomData);
     if (!isValid) {
       scrollToFirstError(roomErrors);
       return;
@@ -192,6 +186,7 @@ export default function AddRoomForm() {
 
     const roomPayload = {
       ...roomData,
+      type: roomType as RoomType,
       id: isEditMode ? editId : Date.now().toString(),
     };
 

--- a/app/guestHouse/guestHouseDetail/_components/GuestHouseInfo.tsx
+++ b/app/guestHouse/guestHouseDetail/_components/GuestHouseInfo.tsx
@@ -5,6 +5,7 @@ import CheckMark from "@/public/svgs/GuestHouse/checkMark.svg";
 import Coffee from "@/public/svgs/GuestHouse/coffee.svg";
 import Wind from "@/public/svgs/GuestHouse/wind.svg";
 import TextSize from "@/src/components/ui/TextSize";
+import { formatMoodLabel } from "@/src/utils/mood";
 import { SetSectionYPositionProps } from "@/src/types/models/stepDetail/SetSectionYPosition";
 import { COLORS } from "@/src/utils/constants/colors";
 
@@ -56,7 +57,7 @@ export default function GuestHouseInfo({
               <TextSize
                 color={`${COLORS.PRIMARY.BLUE}`}
                 size={14}
-                content={`#${mood}`}
+                content={`#${formatMoodLabel(mood)}`}
               />
             </View>
           ))}

--- a/app/guestHouse/guestHouseDetail/_components/GuestHouseParty.tsx
+++ b/app/guestHouse/guestHouseDetail/_components/GuestHouseParty.tsx
@@ -9,6 +9,7 @@ import WideParty from "@/public/svgs/GuestHouse/wideparty.svg";
 import GehaImage from "@/app/step/stepDetail/_components/GehaInfo/GehaImage";
 import SectionYPosition from "@/app/step/stepDetail/_components/SectionYPosition";
 import TextSize from "@/src/components/ui/TextSize";
+import { formatMoodLabel } from "@/src/utils/mood";
 import { PartiesInfo } from "@/src/types/guestHouseDetail/GuestHouseDetailResponse";
 import { SetSectionYPositionProps } from "@/src/types/models/stepDetail/SetSectionYPosition";
 import { PARTY_TYPE_LABEL } from "@/src/utils/constants/partyData";
@@ -88,7 +89,7 @@ export default function GuestHouseParty({
               <View className='flex-row items-center gap-3'>
                 <WideParty width={14} height={14} color='#99A1AF' />
                 <TextSize
-                  content={`파티 분위기: ${party.moods.join(" , ")}`}
+                  content={`파티 분위기: ${party.moods.map(formatMoodLabel).join(" , ")}`}
                   color='#101828'
                   size={14}
                 />

--- a/app/guestHouse/guestHouseDetail/_components/ParlorType.tsx
+++ b/app/guestHouse/guestHouseDetail/_components/ParlorType.tsx
@@ -14,6 +14,18 @@ interface ParlorTypeProps extends SetSectionYPositionProps {
   parlorType?: RoomsInfo[];
 }
 
+const renderRoomTypeIcon = (type: string) => {
+  if (type === "남성전용") {
+    return <Man width={12} height={12} />;
+  }
+
+  if (type === "여성전용") {
+    return <Girl width={12} height={12} />;
+  }
+
+  return <View className='w-3 h-3 rounded-full bg-[#99a1af]' />;
+};
+
 export default function ParlorType({
   setSectionYPositions,
   parlorType,
@@ -35,16 +47,12 @@ export default function ParlorType({
             height={200}
             type={true}
             page={true}
-            headCountType={room.headCountType}
+            headCount={room.headCount}
           />
 
           <View className='p-4 gap-2'>
             <View className='flex-row items-center gap-3'>
-              {room.type === "남성전용" ? (
-                <Man width={12} height={12} />
-              ) : (
-                <Girl width={12} height={12} />
-              )}
+              {renderRoomTypeIcon(room.type)}
               <TextSize
                 content={`${room.type} ${room.name}`}
                 color='#101828'

--- a/app/home/_components/HorizontalSlider.tsx
+++ b/app/home/_components/HorizontalSlider.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import { ScrollView } from "react-native";
 
 interface HorizontalSliderProps<T> {
-  data: T[];
+  data: readonly T[];
   renderItem: (item: T) => ReactNode;
   renderMoreCard?: ReactNode;
 }

--- a/app/home/_components/ItemCard.tsx
+++ b/app/home/_components/ItemCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/src/types/models/home/GuestHouseCard";
 import { COLORS } from "@/src/utils/constants/colors";
 import { buildAssetUrl } from "@/src/config/url";
+import { formatMoodLabel } from "@/src/utils/mood";
 
 interface ItemCardProps {
   item: StepRecommendationCard | guestHouseRecommendationCard;
@@ -60,7 +61,7 @@ export function ItemCard({ item, type }: ItemCardProps) {
             {item.tags.map((tag, index) => (
               <Tag
                 key={index}
-                label={tag}
+                label={isGuestHouse ? formatMoodLabel(tag) : tag}
                 variant='info'
                 size='md'
                 prefix='#'

--- a/app/home/_components/SlideSectionLayout.tsx
+++ b/app/home/_components/SlideSectionLayout.tsx
@@ -51,10 +51,10 @@ export function SlideSectionLayout<
         data={regions}
         renderItem={(region) => (
           <RegionTab
-            key={region}
-            label={region}
-            selected={selectedRegion === region}
-            onPress={() => setSelectedRegion(region)}
+            key={region.value}
+            label={region.label}
+            selected={selectedRegion === region.value}
+            onPress={() => setSelectedRegion(region.value)}
           />
         )}
       />

--- a/app/my/application/status.tsx
+++ b/app/my/application/status.tsx
@@ -18,6 +18,7 @@ import { buildAssetUrl } from "@/src/config/url";
 import { useMyApplicationStatus } from "@/src/hooks/application/myApplication/useMyApplicationStatus";
 import { useCreateChatRoom } from "@/src/hooks/chat/useChat";
 import { COLORS } from "@/src/utils/constants/colors";
+import { formatRegionLabel } from "@/src/utils/region";
 import { router } from "expo-router";
 
 type FilterType = "ALL" | "ACCEPTED";
@@ -148,7 +149,7 @@ export default function MyApplicationStatus() {
                           <TextSize
                             color='#6A7282'
                             size={13}
-                            content={applicationStatus.region}
+                            content={formatRegionLabel(applicationStatus.region)}
                           />
                         </View>
                       </View>

--- a/app/step/_components/BottomSheetModal.tsx
+++ b/app/step/_components/BottomSheetModal.tsx
@@ -78,17 +78,17 @@ export default function BottomSheetModal({
           <View className='flex-row flex-wrap gap-2'>
             {REGION_OPTIONS.map((region) => (
               <TouchableOpacity
-                key={region}
-                onPress={() => toggleRegion(region)}
+                key={region.value}
+                onPress={() => toggleRegion(region.value)}
                 className={`flex-row items-center gap-2 p-3 rounded-lg border ${
-                  filters.region.includes(region)
+                  filters.region.includes(region.value)
                     ? "border-primary-blue bg-blue-50"
                     : "border-gray-200"
                 }`}
                 style={{ width: "48%" }}
               >
-                <Checkbox checked={filters.region.includes(region)} size='md' />
-                <TextSize size={14} content={region} />
+                <Checkbox checked={filters.region.includes(region.value)} size='md' />
+                <TextSize size={14} content={region.label} />
               </TouchableOpacity>
             ))}
           </View>

--- a/app/step/_components/GuestHouseCard.tsx
+++ b/app/step/_components/GuestHouseCard.tsx
@@ -3,6 +3,8 @@ import { useToggleWish } from "@/src/hooks/wish/useToggleWish";
 import { GuestHousePost } from "@/src/types/models/guestHouse/types";
 import { StaffRecruitmentPost } from "@/src/types/models/step/types";
 import { buildAssetUrl } from "@/src/config/url";
+import { formatMoodLabel } from "@/src/utils/mood";
+import { formatRegionLabel } from "@/src/utils/region";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import React, { useEffect, useState } from "react";
@@ -75,13 +77,13 @@ export default function GuestHouseCard({
             {displayTitle}
           </Text>
           <Text className='text-[#495565] text-xs font-normal leading-[18px]'>
-            {item.region}
+            {formatRegionLabel(item.region)}
           </Text>
           <View className='mt-1.5 flex-row gap-1'>
             {item.tags.map((tag, index) => (
               <Tag
                 key={index}
-                label={tag}
+                label={isStepRecruitment ? tag : formatMoodLabel(tag)}
                 variant='info'
                 size='sm'
                 prefix='#'

--- a/app/step/stepDetail/[id]/apply/_components/TargetPostingInfo.tsx
+++ b/app/step/stepDetail/[id]/apply/_components/TargetPostingInfo.tsx
@@ -6,6 +6,7 @@ import Tag from "@/src/components/ui/Tag/Tag";
 import TextSize from "@/src/components/ui/TextSize";
 import { COLORS } from "@/src/utils/constants/colors";
 import { buildAssetUrl } from "@/src/config/url";
+import { formatRegionLabel } from "@/src/utils/region";
 
 interface TargetPostingInfoProps {
   imageUrl: string;
@@ -33,7 +34,11 @@ export default function TargetPostingInfo({
         <Flex justify='center' items='start' gap={6}>
           <TextSize size={17} content={guestHouseName} />
           {region && (
-            <TextSize size={12} color={COLORS.GRAY.TEXT} content={region} />
+            <TextSize
+              size={12}
+              color={COLORS.GRAY.TEXT}
+              content={formatRegionLabel(region)}
+            />
           )}
           <Flex justify='start' items='center' dir='row' gap={3} wrap='wrap'>
             {tags.map((tag, index) => (

--- a/app/step/stepDetail/_components/GehaInfo/GehaImage.tsx
+++ b/app/step/stepDetail/_components/GehaInfo/GehaImage.tsx
@@ -44,7 +44,7 @@ export default function GehaImage({
         <View className='absolute top-3 right-3 z-10'>
           <View className='rounded-xl py-2 px-3 bg-black/70 flex-row gap-1'>
             <Bed width={16} height={16} />
-            <TextSize color='#ffffff' size={14} content={`${headCount ?? 1}인`} />
+            <TextSize color='#ffffff' size={14} content={`${headCount || 1}인`} />
           </View>
         </View>
       )}

--- a/app/step/stepDetail/_components/GehaInfo/GehaImage.tsx
+++ b/app/step/stepDetail/_components/GehaInfo/GehaImage.tsx
@@ -14,7 +14,7 @@ interface GehaImageProps {
   page?: boolean;
   type?: boolean;
   party?: boolean;
-  headCountType?: string;
+  headCount?: number;
 }
 
 export default function GehaImage({
@@ -23,7 +23,7 @@ export default function GehaImage({
   page,
   type,
   party,
-  headCountType,
+  headCount,
 }: GehaImageProps) {
   const {
     modalVisible,
@@ -38,21 +38,13 @@ export default function GehaImage({
     return;
   }
 
-  if (headCountType === "_1인실") {
-    headCountType = "1인실";
-  } else if (headCountType === "_2인실") {
-    headCountType = "2인실";
-  } else if (headCountType === "_3인이상") {
-    headCountType = "3인이상";
-  }
-
   return (
     <View className='w-full' style={{ height }}>
       {type && (
         <View className='absolute top-3 right-3 z-10'>
           <View className='rounded-xl py-2 px-3 bg-black/70 flex-row gap-1'>
             <Bed width={16} height={16} />
-            <TextSize color='#ffffff' size={14} content={headCountType} />
+            <TextSize color='#ffffff' size={14} content={`${headCount ?? 1}인`} />
           </View>
         </View>
       )}

--- a/app/step/stepDetail/_components/GehaInfo/GehaInfo.tsx
+++ b/app/step/stepDetail/_components/GehaInfo/GehaInfo.tsx
@@ -1,6 +1,7 @@
 import { View } from "react-native";
 
 import TextSize from "@/src/components/ui/TextSize";
+import { formatRegionLabel } from "@/src/utils/region";
 
 import GehaLocation from "@/public/svgs/StepDetail/gehaLocation.svg";
 import GehaName from "@/public/svgs/StepDetail/gehaName.svg";
@@ -34,7 +35,7 @@ export default function GehaInfo({
 
       <GehaDetailInfo
         icon={<GehaLocation width={14} height={14} />}
-        content={region}
+        content={formatRegionLabel(region)}
       />
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.5",
         "axios": "^1.13.1",
         "dayjs": "^1.11.19",
-        "expo": "~54.0.34",
+        "expo": "~54.0.36",
         "expo-auth-session": "~7.0.11",
         "expo-checkbox": "~5.0.8",
         "expo-constants": "~18.0.9",
@@ -1804,15 +1804,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
+      "version": "12.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.14.tgz",
+      "integrity": "sha512-3dfbBd9LnPDgyylhCgkOsaG8Adg52uOVOTQYH5lf23a/t8M5eQpXKCvzUarrf62B78057n2NnkiofK9TfPgvzw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.16",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1825,14 +1825,14 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
-      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
+      "version": "54.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.5.tgz",
+      "integrity": "sha512-aWQ3sViNRoQWw6So4A2qhWCt24CuGBK6MrRHI1AG+V6/NQAjIZCHaSvcXK2gXKpmisRhTSUWaKPIgLJQFB+AeQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "~10.0.8",
-        "@expo/plist": "^0.4.8",
+        "@expo/json-file": "~10.0.16",
+        "@expo/plist": "^0.4.9",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -1923,9 +1923,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.11.tgz",
-      "integrity": "sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.12.tgz",
+      "integrity": "sha512-wVfzeBGlUohZG5kS8QCqXurpuWZFJEkBB1wXCifai3EZ/Llcg/VMTiUCpAgHImD3lI7GIU3V1uI64c04XIo98Q==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -2070,55 +2070,6 @@
         "metro-symbolicate": "0.83.3",
         "metro-transform-plugins": "0.83.3",
         "metro-transform-worker": "0.83.3"
-      }
-    },
-    "node_modules/@expo/metro-config": {
-      "version": "54.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
-      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8",
-        "@expo/json-file": "~10.0.16",
-        "@expo/metro": "~54.2.0",
-        "@expo/spawn-async": "^1.7.2",
-        "browserslist": "^4.25.0",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "hermes-parser": "^0.29.1",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "^1.30.1",
-        "picomatch": "^4.0.3",
-        "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/metro-runtime": {
@@ -2346,9 +2297,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.0.tgz",
-      "integrity": "sha512-wKIXL8UtbuX4KwavPasIW3CUcgTbYfjzLcgUhjyKUAYDEqMaf6gmU1bqz3ffBPTokmX+G8/vFG1ZuI9etQWukA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.1.tgz",
+      "integrity": "sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.8.0"
@@ -2358,12 +2309,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.0.tgz",
-      "integrity": "sha512-s3W3eZafJDEyVL7W/jxj2Nz3eONKxSCU604S5xj8ijrVaRz83x0DnZznLf/UXQEI1w+FyibH68nHeQyk767b1A==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.1.tgz",
+      "integrity": "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^11.0.0",
+        "@expo/json-file": "^11.0.1",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2372,9 +2323,9 @@
       }
     },
     "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.0.tgz",
-      "integrity": "sha512-pHJCETqFL5x5BzNV6cEPwjwuECgGmnl0bNmfHIJ6LM1tlh2eVXi5HEdit3zby/JO/B8Otk5cgcqtJXgvvUat3A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
+      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2444,9 +2395,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
-      "integrity": "sha512-9I6ZqvnAvKKDiO+ZF8BpQQFYWXOJvTAL5L/227RUbWG1OVZDInFifzCBiqAZ3b67NRfeAgpgvbA7rejsqhY62A==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.9.tgz",
+      "integrity": "sha512-t9bYwG4Z0yCVzHYJoDMci1OFq2FkBkhStlfUGSkspKYTwB/84+x6sY+CXCgdhkQNQtvWaugW5KUs9YZfAXq9Sg==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -4995,49 +4946,6 @@
         "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
-    "node_modules/babel-preset-expo": {
-      "version": "54.0.11",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
-      "integrity": "sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.5",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.29.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
-        "expo": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
@@ -6611,22 +6519,22 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.35",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
-      "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
+      "version": "54.0.36",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.36.tgz",
+      "integrity": "sha512-HMHp1H+actmnX85NJE6lILKzSJV6pTDNkwghq9EMOP3zTynjvBYVqJGSLlm6sEVzJCC5Z2ZiKgLvtsHrqlY0dg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.25",
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/cli": "54.0.26",
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/devtools": "0.1.8",
         "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.16",
+        "@expo/metro-config": "54.0.17",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.11",
+        "babel-preset-expo": "~54.0.12",
         "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
         "expo-file-system": "~19.0.23",
@@ -7310,26 +7218,26 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.25",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
-      "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
+      "version": "54.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.26.tgz",
+      "integrity": "sha512-BjsAoKINLEo3LRE+sDC6FCgjxuOWsyfOFOKz0txrbEcxSatzIjJDVuX8XaTdmeicZdcoN524yl1sfwCWfxhYMw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/devcert": "^1.2.1",
-        "@expo/env": "~2.0.8",
+        "@expo/env": "~2.0.12",
         "@expo/image-utils": "^0.8.8",
         "@expo/json-file": "^10.0.16",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.16",
+        "@expo/metro-config": "~54.0.17",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
         "@expo/plist": "^0.4.9",
-        "@expo/prebuild-config": "^54.0.8",
-        "@expo/schema-utils": "^0.1.8",
+        "@expo/prebuild-config": "^54.0.9",
+        "@expo/schema-utils": "^0.1.9",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
@@ -7396,6 +7304,107 @@
         }
       }
     },
+    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
+      "version": "54.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.9.tgz",
+      "integrity": "sha512-3/Rmyzt8vduPjnSVHbnc0wYFrlhwLWn2g596rDyKcLGeqN2WTLJbzVeznsrUwyzhBNXgnTomZWO5HDzbZ/4E7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.16",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/metro-config": {
+      "version": "54.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.17.tgz",
+      "integrity": "sha512-PQFgQCZGY0DffZUvBzJttDPreZfHrQakaBlKjnvOUMNXbDna+TYmg1IFZuIDUYJezLcdp+TvVFTLjNi1+mqaVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~12.0.14",
+        "@expo/env": "~2.0.12",
+        "@expo/json-file": "~10.0.16",
+        "@expo/metro": "~54.2.0",
+        "@expo/spawn-async": "^1.7.2",
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.29.1",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "picomatch": "^4.0.3",
+        "postcss": "~8.4.32",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo/node_modules/babel-preset-expo": {
+      "version": "54.0.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.12.tgz",
+      "integrity": "sha512-6xeSkdaixmQhWSYL7tfLu0pOS0BY+8ftwmdNSHtpEFSizrXYZkCjk/B6Dxr+6nwNRihixMcS0aBlWS1wlDl3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "0.81.5",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.29.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "debug": "^4.3.4",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "react-refresh": ">=0.14.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo/node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -7436,9 +7445,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12404,9 +12413,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^5.90.5",
     "axios": "^1.13.1",
     "dayjs": "^1.11.19",
-    "expo": "~54.0.34",
+    "expo": "~54.0.36",
     "expo-auth-session": "~7.0.11",
     "expo-checkbox": "~5.0.8",
     "expo-constants": "~18.0.9",

--- a/src/hooks/guestHouse/useGuestHouseStep4Validation.ts
+++ b/src/hooks/guestHouse/useGuestHouseStep4Validation.ts
@@ -90,8 +90,20 @@ export function useGuestHouseStep4Validation(step4Data: Step4Data) {
     }
 
     if (!room.occupancy) {
-      newErrors.occupancy = "객실 인원을 선택해주세요";
+      newErrors.occupancy = "객실 인원을 입력해주세요";
       isValid = false;
+    } else {
+      const occupancyNumber = parseInt(room.occupancy.replace(/[^0-9]/g, ""), 10);
+      if (isNaN(occupancyNumber)) {
+        newErrors.occupancy = "유효한 객실 인원을 입력해주세요";
+        isValid = false;
+      } else if (occupancyNumber <= 0) {
+        newErrors.occupancy = "객실 인원은 1명 이상이어야 합니다";
+        isValid = false;
+      } else if (occupancyNumber > 99) {
+        newErrors.occupancy = "객실 인원이 너무 많습니다";
+        isValid = false;
+      }
     }
 
     if (!room.checkInTime) {

--- a/src/hooks/guestHouse/useGuestHouseStep4Validation.ts
+++ b/src/hooks/guestHouse/useGuestHouseStep4Validation.ts
@@ -1,6 +1,10 @@
 import { Room, Step4Data } from "@/src/types/models/guestHouse/enroll";
 import { useState } from "react";
 
+type ValidatableRoom = Omit<Room, "type"> & {
+  type: Room["type"] | null;
+};
+
 interface FormErrors {
   rooms: string;
 }
@@ -25,7 +29,9 @@ const initialRoomErrors: RoomAllErrors = {
   images: "",
 };
 
-export function useGuestHouseStep4Validation(step4Data: Step4Data) {
+export function useGuestHouseStep4Validation(
+  step4Data: { rooms: ValidatableRoom[] } | Step4Data
+) {
   const [errors, setErrors] = useState<FormErrors>({
     rooms: "",
   });
@@ -42,7 +48,10 @@ export function useGuestHouseStep4Validation(step4Data: Step4Data) {
   };
 
   //개별 필드 검사
-  const validateRoomField = (room: Room, field: "name" | "price"): void => {
+  const validateRoomField = (
+    room: ValidatableRoom,
+    field: "name" | "price"
+  ): void => {
     let errorMsg = "";
 
     if (field === "name") {
@@ -72,7 +81,7 @@ export function useGuestHouseStep4Validation(step4Data: Step4Data) {
   };
 
   // 저장 버튼용: 모든 필드 검사
-  const validateRoomForm = (room: Room): boolean => {
+  const validateRoomForm = (room: ValidatableRoom): boolean => {
     let isValid = true;
     const newErrors: RoomAllErrors = { ...initialRoomErrors };
 

--- a/src/stores/guestHouse/useGuestHouseStore.ts
+++ b/src/stores/guestHouse/useGuestHouseStore.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { GuestHouseStore } from "@/src/types/store/guestHouseStore";
+import { migrateLegacyMoodValues } from "@/src/utils/mood";
+import { migrateLegacyRegionValue } from "@/src/utils/region";
 import {
   createStep1Slice,
   initialStep1Data,
@@ -53,6 +55,24 @@ export const useGuestHouseStore = create<GuestHouseStore>()(
     {
       name: "guesthouse-enrollment-storage",
       storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
+      migrate: (persistedState) => {
+        const state = persistedState as {
+          step1Data?: { workingRegion?: string };
+          step2Data?: { atmosphere?: string[] };
+        };
+        if (state?.step1Data?.workingRegion) {
+          state.step1Data.workingRegion = migrateLegacyRegionValue(
+            state.step1Data.workingRegion
+          );
+        }
+        if (state?.step2Data?.atmosphere) {
+          state.step2Data.atmosphere = migrateLegacyMoodValues(
+            state.step2Data.atmosphere
+          );
+        }
+        return state;
+      },
     }
   )
 );

--- a/src/stores/stepRecruitment/useStepRecruitmentStore.ts
+++ b/src/stores/stepRecruitment/useStepRecruitmentStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 import { StepRecruitmentStore } from '@/src/types/store/stepRecruitmentStore';
+import { migrateLegacyRegionValue } from '@/src/utils/region';
 import { createStep1Slice, initialStep1Data } from './slice/createStep1Slice';
 import { createStep2Slice, initialStep2Data } from './slice/createStep2Slice';
 import { createStep3Slice, initialStep3Data } from './slice/createStep3Slice';
@@ -59,6 +60,16 @@ export const useStepRecruitmentStore = create<StepRecruitmentStore>()(
     {
       name: 'step-recruitment-storage',
       storage: asyncStorageWithDateReviver,
+      version: 1,
+      migrate: (persistedState) => {
+        const state = persistedState as { step1Data?: { workingRegion?: string } };
+        if (state?.step1Data?.workingRegion) {
+          state.step1Data.workingRegion = migrateLegacyRegionValue(
+            state.step1Data.workingRegion
+          );
+        }
+        return state;
+      },
     }
   )
 );

--- a/src/types/api/guestHouse/GuestHouseEnrollRequest.ts
+++ b/src/types/api/guestHouse/GuestHouseEnrollRequest.ts
@@ -30,7 +30,7 @@ export interface PartyRequest {
 export interface RoomRequest {
   name: string;
   type: string;
-  headCountType: string;
+  headCount: number;
   checkInTime: string;
   checkOutTime: string;
   pricePerNight: number;

--- a/src/types/guestHouseDetail/GuestHouseDetailResponse.ts
+++ b/src/types/guestHouseDetail/GuestHouseDetailResponse.ts
@@ -42,7 +42,7 @@ export interface PartiesInfo {
 export interface RoomsInfo {
   name: string;
   type: string;
-  headCountType: string;
+  headCount: number;
   checkInTime: string;
   checkOutTime: string;
   pricePerNight: number;

--- a/src/types/models/guestHouse/enroll/index.ts
+++ b/src/types/models/guestHouse/enroll/index.ts
@@ -20,8 +20,8 @@ export interface Party {
 export interface Room {
   id: string;
   name: string;
-  type: '여성 전용 도미토리' | '남성 전용 도미토리';
-  occupancy: '1인실' | '2인실' | '3인이상';
+  type: '여성 전용 도미토리' | '남성 전용 도미토리' | '기타';
+  occupancy: string;
   checkInTime: Date;
   checkOutTime: Date;
   price: string;

--- a/src/utils/constants/filterOptions.ts
+++ b/src/utils/constants/filterOptions.ts
@@ -1,11 +1,11 @@
 // 공통
 export const REGION_OPTIONS = [
-  "제주시",
-  "서귀포시",
-  "서부권",
-  "동부권",
-  "도서지역",
-  "중문_대정",
+  { value: "제주시", label: "제주시" },
+  { value: "서귀포시", label: "서귀포시" },
+  { value: "중문", label: "중문" },
+  { value: "성산_구좌", label: "성산/구좌" },
+  { value: "애월_협재", label: "애월/협재" },
+  { value: "우도_기타", label: "우도/기타" },
 ] as const;
 
 export const SORT_OPTIONS = [
@@ -38,14 +38,17 @@ export const GENDER_OPTIONS = ["무관", "남", "여"] as const;
 
 // 게하 목록
 export const MOOD_OPTIONS = [
+  { label: "#바닷가", value: "바닷가" },
+  { label: "#동물", value: "동물" },
+  { label: "#자연∙숲", value: "자연_숲" },
+  { label: "#대규모파티", value: "대규모파티" },
+  { label: "#소규모파티", value: "소규모파티" },
   { label: "#조용한", value: "조용한" },
-  { label: "#사교적", value: "사교적" },
-  { label: "#힐링", value: "힐링" },
-  { label: "#사색", value: "사색" },
   { label: "#활발한", value: "활발한" },
-  { label: "#잔잔한", value: "잔잔한" },
-  { label: "#감성", value: "감성" },
-  { label: "#휴식", value: "휴식" },
+  { label: "#감성∙느좋", value: "감성_느좋" },
+  { label: "#파티 X", value: "파티_X" },
+  { label: "#솔로", value: "솔로" },
+  { label: "#한달살이", value: "한달살이" },
 ];
 
 export const ROOM_PRICE_OPTIONS = [
@@ -65,6 +68,7 @@ export const PARTY_TYPE_OPTIONS = [
 export const ROOM_TYPE_OPTIONS = [
   { label: "여성전용 도미토리", value: "여성전용" },
   { label: "남성전용 도미토리", value: "남성전용" },
+  { label: "기타", value: "기타" },
 ];
 
 export const HEAD_COUNT_TYPE_OPTIONS = [

--- a/src/utils/constants/guestHouseEnrollment.ts
+++ b/src/utils/constants/guestHouseEnrollment.ts
@@ -1,3 +1,5 @@
+import { MOOD_OPTIONS } from './filterOptions';
+
 /**
  * 게스트하우스 등록 관련 상수
  */
@@ -20,16 +22,7 @@ export const FACILITY_OPTIONS = [
 /**
  * 분위기 옵션
  */
-export const ATMOSPHERE_OPTIONS = [
-  '감성',
-  '조용한',
-  '휴식',
-  '활발한',
-  '사교적',
-  '힐링',
-  '사색',
-  '잔잔한',
-] as const;
+export const ATMOSPHERE_OPTIONS = MOOD_OPTIONS;
 
 /**
  * 파티 타입 옵션
@@ -70,12 +63,12 @@ export const ROOM_TYPES = [
     value: '남성 전용 도미토리',
     color: '#3b82f6',
   },
+  {
+    label: '기타',
+    value: '기타',
+    color: '#99a1af',
+  },
 ] as const;
-
-/**
- * 객실 인원 옵션
- */
-export const OCCUPANCY_OPTIONS = ['1인실', '2인실', '3인이상'] as const;
 
 // ========================================
 // 업로드 제한
@@ -234,6 +227,7 @@ export const FORM_DESCRIPTIONS = {
 export const ROOM_TYPE_COLORS = {
   FEMALE: '#fa2b36',
   MALE: '#3b82f6',
+  ETC: '#99a1af',
   PLACEHOLDER: '#99a1af',
 } as const;
 
@@ -245,4 +239,3 @@ export type FacilityOption = (typeof FACILITY_OPTIONS)[number];
 export type AtmosphereOption = (typeof ATMOSPHERE_OPTIONS)[number];
 export type PartyType = (typeof PARTY_TYPES)[number];
 export type DayOfWeek = (typeof DAYS_OF_WEEK_SIMPLE)[number];
-export type OccupancyOption = (typeof OCCUPANCY_OPTIONS)[number];

--- a/src/utils/constants/options.ts
+++ b/src/utils/constants/options.ts
@@ -2,6 +2,7 @@ import { Gender } from "@/src/types/Gender";
 import { PerWorkingDay } from "@/src/types/models/stepRecruitment/PerWorkingDay";
 
 import { Option } from "@/src/types/Option";
+import { REGION_OPTIONS } from "./filterOptions";
 
 export const STYLE_OPTIONS: Option[] = [
   { value: "친근한", label: "#친근한" },
@@ -33,14 +34,7 @@ export const DAYS_OF_WEEK: Option[] = [
   { value: "일", label: "일" },
 ];
 
-export const REGION_OPTION: Option[] = [
-  { value: "제주시", label: "제주시" },
-  { value: "서귀포시", label: "서귀포시" },
-  { value: "서부권", label: "서부권" },
-  { value: "동부권", label: "동부권" },
-  { value: "중문_대정", label: "중문_대정" },
-  { value: "도서지역", label: "도서지역" },
-];
+export const REGION_OPTION: Option[] = [...REGION_OPTIONS];
 
 export const WORKING_PERIOD = [
   { value: "단기", label: "단기", content: "4주 이하" },

--- a/src/utils/constants/regions.ts
+++ b/src/utils/constants/regions.ts
@@ -1,8 +1,1 @@
- export const regions: string[] = [
-    "제주시",
-    "서귀포시",
-    "서부권",
-    "동부권",
-    "중문_대정",
-    "도서지역",
-  ];
+export { REGION_OPTIONS as regions } from "./filterOptions";

--- a/src/utils/guestHouse/enrollDataTransformer.ts
+++ b/src/utils/guestHouse/enrollDataTransformer.ts
@@ -27,12 +27,14 @@ const transformRoomType = (type: string): string => {
   const typeMap: Record<string, string> = {
     '여성 전용 도미토리': '여성전용',
     '남성 전용 도미토리': '남성전용',
+    기타: '기타',
   };
   return typeMap[type] || type;
 };
 
-const transformOccupancy = (occupancy: string): string => {
-  return `_${occupancy}`;
+const transformOccupancy = (occupancy: string): number => {
+  const occupancyNumber = parseInt(occupancy.replace(/[^0-9]/g, ''), 10);
+  return Number.isNaN(occupancyNumber) ? 1 : occupancyNumber;
 };
 
 const transformAmenity = (amenity: string): string => {
@@ -84,7 +86,7 @@ const transformRoom = (room: Room): RoomRequest => {
   return {
     name: room.name,
     type: transformRoomType(room.type),
-    headCountType: transformOccupancy(room.occupancy),
+    headCount: transformOccupancy(room.occupancy),
     checkInTime: formatTime(room.checkInTime),
     checkOutTime: formatTime(room.checkOutTime),
     pricePerNight: transformPrice(room.price, '1박 가격'),

--- a/src/utils/guestHouse/transformGuestHouseApiToStore.ts
+++ b/src/utils/guestHouse/transformGuestHouseApiToStore.ts
@@ -24,19 +24,13 @@ const reversePartyType = (type: string): string => {
   return map[type] ?? type;
 };
 
-const reverseRoomType = (type: string): '여성 전용 도미토리' | '남성 전용 도미토리' => {
+const reverseRoomType = (type: string): '여성 전용 도미토리' | '남성 전용 도미토리' | '기타' => {
   if (type === '여성전용') return '여성 전용 도미토리';
+  if (type === '기타') return '기타';
   return '남성 전용 도미토리';
 };
 
-const reverseOccupancy = (headCountType: string): '1인실' | '2인실' | '3인이상' => {
-  const map: Record<string, '1인실' | '2인실' | '3인이상'> = {
-    '_1인실': '1인실',
-    '_2인실': '2인실',
-    '_3인이상': '3인이상',
-  };
-  return map[headCountType] ?? '1인실';
-};
+const reverseOccupancy = (headCount?: number): string => String(headCount ?? 1);
 
 const reverseAmenity = (amenity: string): string => amenity.replace(/_/g, ' ');
 
@@ -59,7 +53,7 @@ const transformRoom = (room: RoomsInfo, index: number): Room => ({
   id: `${Date.now()}_${index}`,
   name: room.name,
   type: reverseRoomType(room.type),
-  occupancy: reverseOccupancy(room.headCountType),
+  occupancy: reverseOccupancy(room.headCount),
   checkInTime: parseTimeString(room.checkInTime),
   checkOutTime: parseTimeString(room.checkOutTime),
   price: String(room.pricePerNight),

--- a/src/utils/guestHouse/transformGuestHouseApiToStore.ts
+++ b/src/utils/guestHouse/transformGuestHouseApiToStore.ts
@@ -30,7 +30,7 @@ const reverseRoomType = (type: string): '여성 전용 도미토리' | '남성 �
   return '남성 전용 도미토리';
 };
 
-const reverseOccupancy = (headCount?: number): string => String(headCount ?? 1);
+const reverseOccupancy = (headCount?: number): string => String(headCount || 1);
 
 const reverseAmenity = (amenity: string): string => amenity.replace(/_/g, ' ');
 

--- a/src/utils/mood.ts
+++ b/src/utils/mood.ts
@@ -1,0 +1,29 @@
+import { MOOD_OPTIONS } from "./constants/filterOptions";
+
+const MOOD_LABELS: Record<string, string> = Object.fromEntries(
+  MOOD_OPTIONS.map((option) => [option.value, option.label.replace(/^#/, "")])
+);
+
+export const formatMoodLabel = (mood?: string | null) => {
+  if (!mood) {
+    return "";
+  }
+
+  return MOOD_LABELS[mood] ?? mood;
+};
+
+// 2026-07-19 분위기 개편 이전 값 -> 이후 값. 기기에 남아있는 임시저장 데이터를 위해 유지.
+const LEGACY_MOOD_MIGRATION_MAP: Record<string, string> = {
+  사교적: "소규모파티",
+  힐링: "자연_숲",
+  사색: "조용한",
+  잔잔한: "조용한",
+  감성: "감성_느좋",
+  휴식: "한달살이",
+};
+
+export const migrateLegacyMoodValue = (mood: string) =>
+  LEGACY_MOOD_MIGRATION_MAP[mood] ?? mood;
+
+export const migrateLegacyMoodValues = (moods: string[]) =>
+  Array.from(new Set(moods.map(migrateLegacyMoodValue)));

--- a/src/utils/region.ts
+++ b/src/utils/region.ts
@@ -1,0 +1,24 @@
+import { REGION_OPTIONS } from "./constants/filterOptions";
+
+const REGION_LABELS: Record<string, string> = Object.fromEntries(
+  REGION_OPTIONS.map((option) => [option.value, option.label])
+);
+
+export const formatRegionLabel = (region?: string | null) => {
+  if (!region) {
+    return "";
+  }
+
+  return REGION_LABELS[region] ?? region;
+};
+
+// 2026-07-17 지역 개편 이전 값 -> 이후 값. 기기에 남아있는 임시저장 데이터를 위해 유지.
+const LEGACY_REGION_MIGRATION_MAP: Record<string, string> = {
+  서부권: "애월_협재",
+  동부권: "성산_구좌",
+  도서지역: "우도_기타",
+  중문_대정: "중문",
+};
+
+export const migrateLegacyRegionValue = (region: string) =>
+  LEGACY_REGION_MIGRATION_MAP[region] ?? region;


### PR DESCRIPTION
## 관련 이슈

---

## 작업 내용

- 지역 옵션 개편 반영
지역 목록을 제주시, 서귀포시, 중문, 성산/구좌, 애월/협재, 우도/기타 기준으로 변경

- 게스트하우스 분위기 옵션 개편 반영
분위기 옵션을 바닷가, 동물, 자연∙숲, 대규모파티, 소규모파티, 조용한, 활발한, 감성∙느좋, 파티 X, 솔로, 한달살이 기준으로 변경

- 객실 타입 및 인원 입력 방식 변경
객실 타입에 기타를 추가하고 회색 표시를 적용했습니다.
객실 인원을 기존 1인실 / 2인실 / 3인이상 선택 방식에서 숫자 입력 방식으로 변경

- Expo SDK patch 버전 정렬
expo-doctor에서 발생하던 Expo patch 버전 mismatch를 해결하기 위해 expo 버전을 SDK 기대 버전 조정

---
