### PR TITLE
fix: 네이버 지도 API 보안 개선 및 지도 지역 옵션 동기화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 EXPO_PUBLIC_API_URL=
 EXPO_PUBLIC_BASE_URL=
 EXPO_PUBLIC_ASSET_URL=
-GOOGLE_MAPS_API_KEY=
+
+# Naver Map SDK client id for native map rendering.
+# Do not put Naver client secrets in the frontend env.
+NAVER_MAP_CLIENT_ID=
+EXPO_PUBLIC_NAVER_MAP_CLIENT_ID=
+
+EXPO_PUBLIC_SENTRY_DSN=

--- a/app.config.ts
+++ b/app.config.ts
@@ -38,7 +38,7 @@ if (sentryOrg && sentryProject && sentryAuthToken) {
 const config: ExpoConfig = {
   name: "게하르방",
   slug: "Geharbang-FE",
-  version: "1.2.2",
+  version: "1.2.3",
   orientation: "portrait",
   icon: "./assets/icon.png",
   scheme: "geharbang",
@@ -49,6 +49,7 @@ const config: ExpoConfig = {
   ios: {
     supportsTablet: true,
     bundleIdentifier: "com.econovation.geharbang",
+    buildNumber: "11",
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
 
@@ -61,7 +62,7 @@ const config: ExpoConfig = {
   },
 
   android: {
-    versionCode: 10,
+    versionCode: 11,
     softwareKeyboardLayoutMode: "resize",
     adaptiveIcon: {
       foregroundImage: "./assets/adaptive-icon.png",

--- a/app.config.ts
+++ b/app.config.ts
@@ -102,7 +102,6 @@ const config: ExpoConfig = {
       projectId: "81bf359a-a232-4d2e-bf98-50c02b62485d",
     },
     naverMapClientId: process.env.NAVER_MAP_CLIENT_ID,
-    naverMapClientSecret: process.env.NAVER_MAP_CLIENT_SECRET,
   },
 };
 

--- a/app/(tabs)/map.tsx
+++ b/app/(tabs)/map.tsx
@@ -24,9 +24,10 @@ const JEJU_CENTER = { latitude: 33.3617, longitude: 126.5292, zoom: 9 };
 const REGION_CAMERAS: Record<string, { latitude: number; longitude: number; zoom: number }> = {
   제주시: { latitude: 33.4996, longitude: 126.5312, zoom: 12 },
   서귀포시: { latitude: 33.2541, longitude: 126.5600, zoom: 12 },
-  서부권: { latitude: 33.4139, longitude: 126.2663, zoom: 11 },
-  동부권: { latitude: 33.4440, longitude: 126.9229, zoom: 11 },
-  중문_대정: { latitude: 33.2510, longitude: 126.4130, zoom: 11 },
+  중문: { latitude: 33.2510, longitude: 126.4130, zoom: 11 },
+  성산_구좌: { latitude: 33.4440, longitude: 126.9229, zoom: 11 },
+  애월_협재: { latitude: 33.4139, longitude: 126.2663, zoom: 11 },
+  우도_기타: { latitude: 33.5054, longitude: 126.9559, zoom: 12 },
 };
 
 const NORMAL_W = 36;

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,8 +54,10 @@
       },
       "devDependencies": {
         "@expo/ngrok": "^4.1.3",
+        "@react-native/metro-babel-transformer": "^0.86.0",
         "@tanstack/eslint-plugin-query": "^5.91.2",
         "@types/react": "~19.1.0",
+        "babel-preset-expo": "~54.0.10",
         "react-native-svg-transformer": "^1.5.1",
         "react-test-renderer": "19.1.0",
         "tailwindcss": "^3.4.18",
@@ -3236,6 +3238,136 @@
         "node": ">= 20.19.4"
       }
     },
+    "node_modules/@react-native/metro-babel-transformer": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.86.0.tgz",
+      "integrity": "sha512-SjKej3E5qIahqo/G+rSOrmJUQM44RyKtWtO+VfmKAAMoJWkBFomM22hTLKCIS5cdbIAJ9COAmU+KAi2wVSO0wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@react-native/babel-preset": "0.86.0",
+        "hermes-parser": "0.36.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.86.0.tgz",
+      "integrity": "sha512-qdsABWNW7uTll90l4Vh03gjeyu3WVDi2CyiiyvYGMRDcoYbjbQi6df3BMAm9lQI2yslZ1T14LlDDAsgTwNxplA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.0",
+        "@react-native/codegen": "0.86.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/babel-preset": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.86.0.tgz",
+      "integrity": "sha512-bYQcWiPySNvF4dns9Ls9gMmwgq66ohvM9Fwc/Kn8r85t66UNHxch3p1QwPiSorDelFauZwJbgo9+ReibTgvpbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@react-native/babel-plugin-codegen": "0.86.0",
+        "babel-plugin-syntax-hermes-parser": "0.36.0",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/@react-native/codegen": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
+      "integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.29.0",
+        "hermes-parser": "0.36.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "tinyglobby": "^0.2.15",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.36.0"
+      }
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-estree": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+      "integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-parser": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+      "integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.36.0"
+      }
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
@@ -4950,6 +5082,49 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-expo": {
+      "version": "54.0.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.12.tgz",
+      "integrity": "sha512-6xeSkdaixmQhWSYL7tfLu0pOS0BY+8ftwmdNSHtpEFSizrXYZkCjk/B6Dxr+6nwNRihixMcS0aBlWS1wlDl3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/plugin-proposal-decorators": "^7.12.9",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/preset-react": "^7.22.15",
+        "@babel/preset-typescript": "^7.23.0",
+        "@react-native/babel-preset": "0.81.5",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.29.1",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "debug": "^4.3.4",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "react-refresh": ">=0.14.0 <1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-preset-jest": {
@@ -7363,49 +7538,6 @@
         "expo": "*"
       },
       "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "54.0.12",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.12.tgz",
-      "integrity": "sha512-6xeSkdaixmQhWSYL7tfLu0pOS0BY+8ftwmdNSHtpEFSizrXYZkCjk/B6Dxr+6nwNRihixMcS0aBlWS1wlDl3pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-transform-class-static-block": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/preset-react": "^7.22.15",
-        "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.81.5",
-        "babel-plugin-react-compiler": "^1.0.0",
-        "babel-plugin-react-native-web": "~0.21.0",
-        "babel-plugin-syntax-hermes-parser": "^0.29.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "debug": "^4.3.4",
-        "resolve-from": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.20.0",
-        "expo": "*",
-        "react-refresh": ">=0.14.0 <1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/runtime": {
-          "optional": true
-        },
         "expo": {
           "optional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geharbang-fe",
-  "version": "1.0.0",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geharbang-fe",
-      "version": "1.0.0",
+      "version": "1.2.3",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
         "@mj-studio/react-native-naver-map": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geharbang-fe",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "1.2.3",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
   },
   "devDependencies": {
     "@expo/ngrok": "^4.1.3",
+    "@react-native/metro-babel-transformer": "^0.86.0",
     "@tanstack/eslint-plugin-query": "^5.91.2",
     "@types/react": "~19.1.0",
+    "babel-preset-expo": "~54.0.10",
     "react-native-svg-transformer": "^1.5.1",
     "react-test-renderer": "19.1.0",
     "tailwindcss": "^3.4.18",

--- a/src/components/map/RegionFilter.tsx
+++ b/src/components/map/RegionFilter.tsx
@@ -1,5 +1,5 @@
 import { Pressable, ScrollView, Text } from 'react-native';
-import { regions } from '@/src/utils/constants/regions';
+import { REGION_OPTIONS } from '@/src/utils/constants/filterOptions';
 import { COLORS } from '@/src/utils/constants/colors';
 
 interface RegionFilterProps {
@@ -7,15 +7,7 @@ interface RegionFilterProps {
   onSelect: (region: string | null) => void;
 }
 
-const REGION_LABELS: Record<string, string> = {
-  제주시: '제주시',
-  서귀포시: '서귀포시',
-  서부권: '서부권',
-  동부권: '동부권',
-  중문_대정: '중문·대정',
-};
-
-const MAP_REGIONS = regions.filter((r) => r !== '도서지역');
+const MAP_REGIONS = REGION_OPTIONS;
 
 export default function RegionFilter({ selectedRegion, onSelect }: RegionFilterProps) {
   return (
@@ -26,11 +18,11 @@ export default function RegionFilter({ selectedRegion, onSelect }: RegionFilterP
       style={{ marginTop: 8 }}
     >
       {MAP_REGIONS.map((region) => {
-        const isSelected = selectedRegion === region;
+        const isSelected = selectedRegion === region.value;
         return (
           <Pressable
-            key={region}
-            onPress={() => onSelect(isSelected ? null : region)}
+            key={region.value}
+            onPress={() => onSelect(isSelected ? null : region.value)}
             style={{
               paddingHorizontal: 14,
               paddingVertical: 7,
@@ -47,7 +39,7 @@ export default function RegionFilter({ selectedRegion, onSelect }: RegionFilterP
                 color: isSelected ? 'white' : COLORS.GRAY.TEXT,
               }}
             >
-              {REGION_LABELS[region] ?? region}
+              {region.label}
             </Text>
           </Pressable>
         );

--- a/src/services/map/naverMap.ts
+++ b/src/services/map/naverMap.ts
@@ -14,7 +14,7 @@ export async function localSearch(query: string): Promise<NaverAddressResult[]> 
     const response = await axiosPublic.get<NaverAddressResult[]>("/api/v1/maps/local-search", {
       params: { query },
     });
-    return response.data;
+    return response.data ?? [];
   } catch (e) {
     console.warn("[NaverMap] localSearch 오류:", e);
     return [];
@@ -28,7 +28,7 @@ export async function geocodeAddress(query: string): Promise<NaverAddressResult[
     const response = await axiosPublic.get<NaverAddressResult[]>("/api/v1/maps/geocode", {
       params: { query },
     });
-    return response.data;
+    return response.data ?? [];
   } catch (e) {
     console.warn("[NaverMap] geocode 오류:", e);
     return [];
@@ -46,7 +46,7 @@ export async function reverseGeocode(
         params: { lat, lng },
       },
     );
-    return response.data;
+    return response.data ?? { roadAddress: "", jibunAddress: "" };
   } catch (e) {
     console.warn("[NaverMap] reverseGeocode 오류:", e);
     return { roadAddress: "", jibunAddress: "" };

--- a/src/services/map/naverMap.ts
+++ b/src/services/map/naverMap.ts
@@ -1,13 +1,4 @@
-const CLIENT_ID = process.env.EXPO_PUBLIC_NAVER_MAP_CLIENT_ID ?? "";
-const CLIENT_SECRET = process.env.EXPO_PUBLIC_NAVER_MAP_CLIENT_SECRET ?? "";
-
-const LOCAL_CLIENT_ID = process.env.EXPO_PUBLIC_NAVER_LOCAL_CLIENT_ID ?? "";
-const LOCAL_CLIENT_SECRET = process.env.EXPO_PUBLIC_NAVER_LOCAL_CLIENT_SECRET ?? "";
-
-const NAVER_HEADERS = {
-  "X-NCP-APIGW-API-KEY-ID": CLIENT_ID,
-  "X-NCP-APIGW-API-KEY": CLIENT_SECRET,
-};
+import { axiosPublic } from "@/src/services/api/customAxios";
 
 export interface NaverAddressResult {
   roadAddress: string;
@@ -18,47 +9,12 @@ export interface NaverAddressResult {
 
 export async function localSearch(query: string): Promise<NaverAddressResult[]> {
   if (!query.trim()) return [];
-  if (!LOCAL_CLIENT_ID) {
-    console.warn("[NaverMap] LOCAL_CLIENT_ID 없음 — env var 확인 필요");
-    return [];
-  }
 
   try {
-    const url = `https://openapi.naver.com/v1/search/local.json?query=${encodeURIComponent(query)}&display=5`;
-    const response = await fetch(url, {
-      headers: {
-        "X-Naver-Client-Id": LOCAL_CLIENT_ID,
-        "X-Naver-Client-Secret": LOCAL_CLIENT_SECRET,
-      },
+    const response = await axiosPublic.get<NaverAddressResult[]>("/api/v1/maps/local-search", {
+      params: { query },
     });
-
-    if (!response.ok) {
-      console.warn("[NaverMap] localSearch 실패:", response.status, await response.text().catch(() => ""));
-      return [];
-    }
-
-    const data = await response.json();
-    console.log("[NaverMap] localSearch 결과:", JSON.stringify(data.items?.slice(0, 2)));
-    if (!data.items || data.items.length === 0) return [];
-
-    const results = await Promise.all(
-      data.items.map(async (item: any) => {
-        const address = item.roadAddress || item.address || "";
-        if (!address) return null;
-
-        const geocoded = await geocodeAddress(address);
-        if (geocoded.length === 0) return null;
-
-        return {
-          roadAddress: item.roadAddress ?? "",
-          jibunAddress: item.address ?? "",
-          latitude: geocoded[0].latitude,
-          longitude: geocoded[0].longitude,
-        } as NaverAddressResult;
-      }),
-    );
-
-    return results.filter((r): r is NaverAddressResult => r !== null);
+    return response.data;
   } catch (e) {
     console.warn("[NaverMap] localSearch 오류:", e);
     return [];
@@ -69,24 +25,12 @@ export async function geocodeAddress(query: string): Promise<NaverAddressResult[
   if (!query.trim()) return [];
 
   try {
-    const url = `https://maps.apigw.ntruss.com/map-geocode/v2/geocode?query=${encodeURIComponent(query)}&count=5`;
-    const response = await fetch(url, { headers: NAVER_HEADERS });
-
-    if (!response.ok) {
-      console.warn("[NaverMap] geocode 실패:", response.status, await response.text().catch(() => ""));
-      return [];
-    }
-
-    const data = await response.json();
-    if (!data.addresses || data.addresses.length === 0) return [];
-
-    return data.addresses.map((addr: any) => ({
-      roadAddress: addr.roadAddress ?? "",
-      jibunAddress: addr.jibunAddress ?? "",
-      latitude: parseFloat(addr.y),
-      longitude: parseFloat(addr.x),
-    }));
-  } catch {
+    const response = await axiosPublic.get<NaverAddressResult[]>("/api/v1/maps/geocode", {
+      params: { query },
+    });
+    return response.data;
+  } catch (e) {
+    console.warn("[NaverMap] geocode 오류:", e);
     return [];
   }
 }
@@ -96,38 +40,15 @@ export async function reverseGeocode(
   lng: number,
 ): Promise<{ roadAddress: string; jibunAddress: string }> {
   try {
-    const url = `https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc?coords=${lng},${lat}&output=json&orders=roadaddr,addr`;
-    const response = await fetch(url, { headers: NAVER_HEADERS });
-
-    if (!response.ok) {
-      console.warn("[NaverMap] reverseGeocode 실패:", response.status, await response.text().catch(() => ""));
-      return { roadAddress: "", jibunAddress: "" };
-    }
-
-    const data = await response.json();
-    const results: any[] = data.results ?? [];
-
-    const roadResult = results.find((r) => r.name === "roadaddr");
-    const addrResult = results.find((r) => r.name === "addr");
-
-    const buildAddress = (r: any, includeRoadName: boolean) => {
-      if (!r) return "";
-      const area1 = r.region?.area1?.name ?? "";
-      const area2 = r.region?.area2?.name ?? "";
-      const area3 = r.region?.area3?.name ?? "";
-      const landName = includeRoadName ? (r.land?.name ?? "") : "";
-      const num1 = r.land?.number1 ?? "";
-      const num2 = r.land?.number2 ? `-${r.land.number2}` : "";
-      return [area1, area2, area3, landName, `${num1}${num2}`]
-        .filter(Boolean)
-        .join(" ");
-    };
-
-    return {
-      roadAddress: buildAddress(roadResult, true),
-      jibunAddress: buildAddress(addrResult, false),
-    };
-  } catch {
+    const response = await axiosPublic.get<{ roadAddress: string; jibunAddress: string }>(
+      "/api/v1/maps/reverse-geocode",
+      {
+        params: { lat, lng },
+      },
+    );
+    return response.data;
+  } catch (e) {
+    console.warn("[NaverMap] reverseGeocode 오류:", e);
     return { roadAddress: "", jibunAddress: "" };
   }
 }


### PR DESCRIPTION
## 관련 이슈

---

## 작업 내용

### 네이버 지도 API 호출 구조 개선

- 기존 FE에서 직접 호출하던 네이버 Local Search / Geocode / Reverse Geocode API를 자체 백엔드 API 호출 방식으로 변경
- `EXPO_PUBLIC_NAVER_*_SECRET` 값을 사용하는 클라이언트 직접 호출 로직을 제거
- `app.config.ts`에서 `naverMapClientSecret` 노출 항목을 제거
- `.env.example`에는 지도 SDK 렌더링에 필요한 공개 Client ID만 남기고, Secret은 프론트에 넣지 않도록 주석을 추가

### 지도 지역 필터 옵션 동기화

- 지도 탭의 지역 필터가 기존 구 지역값을 사용하던 문제를 수정
- `REGION_OPTIONS`를 사용하도록 변경
- 지도 카메라 이동 좌표를 신규 지역 체계에 맞게 업데이트
  - 제주시
  - 서귀포시
  - 중문
  - 성산/구좌
  - 애월/협재
  - 우도/기타

### Android 개발 빌드 의존성 보강
- Android dev-client 실행 중 Metro/Babel 변환 관련 모듈 누락 문제가 발생하지 않도록 필요한 devDependency를 추가
  - `@react-native/metro-babel-transformer`
  - `babel-preset-expo`

